### PR TITLE
Destroy the correct stack

### DIFF
--- a/HelloHttp4k-serverless-graal/destroy.sh
+++ b/HelloHttp4k-serverless-graal/destroy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-pulumi destroy --yes --stack aws
+pulumi destroy --yes --stack graalvm


### PR DESCRIPTION
HelloHttp4k-serverless-graal/destroy.sh appears to destroy the wrong stack. This change causes it to destroy the graalvm stack that was created by the deploy.sh script in the same module.
